### PR TITLE
Fix possible typo

### DIFF
--- a/1.0/responses/errors.md
+++ b/1.0/responses/errors.md
@@ -383,7 +383,7 @@ the request `is()` method to check if the path is our API:
 
 ```php
 $this->renderable(ExceptionParser::make()
-    ->accept(fn(\Throwable $ex, $request) => $request->is('/api*'))
+    ->accept(fn(\Throwable $ex, $request) => $request->is('api/*'))
     ->renderable()
 );
 ```


### PR DESCRIPTION
For this example to match all routes starting with `/api` we have to match `api/*` not `/api*`