### PR TITLE
Fix documentation typo

### DIFF
--- a/1.0/requests/query-parameters.md
+++ b/1.0/requests/query-parameters.md
@@ -505,7 +505,7 @@ use LaravelJsonApi\Validation\Rule as JsonApiRule;
 public function rules(): array
 {
   return [
-      'filter' => [
+      'include' => [
         'nullable',
         'string',
         JsonApiRule::includePaths(),


### PR DESCRIPTION
This is the include paths section, but the example shows the `filter` key instead of `include` key which is supposed to be used for rules regarding the `include` feature.