### PR TITLE
Fix "incorrect" example for `creating` model event

### DIFF
--- a/1.0/tutorial/05-creating-resources.md
+++ b/1.0/tutorial/05-creating-resources.md
@@ -165,7 +165,9 @@ Open the `app/JsonApi/V1/Server.php` class, and update it as follows:
      public function serving(): void
      {
 -       // no-op
-+       Post::creating(static fn(Post $post) => $post->author()->associate(Auth::user()));
++       Post::creating(static function (Post $post) {
++.           $post->author()->associate(Auth::user());
++       });
      }
 
      /**
@@ -326,7 +328,9 @@ the `serving()` method:
  {
 +    Auth::shouldUse('sanctum');
 +
-     Post::creating(static fn(Post $post) => $post->author()->associate(Auth::user()));
+     Post::creating(static function(Post $post) {
+         $post->author()->associate(Auth::user());
+     });
  }
 ```
 

--- a/2.0/tutorial/05-creating-resources.md
+++ b/2.0/tutorial/05-creating-resources.md
@@ -165,7 +165,9 @@ Open the `app/JsonApi/V1/Server.php` class, and update it as follows:
      public function serving(): void
      {
 -       // no-op
-+       Post::creating(static fn(Post $post) => $post->author()->associate(Auth::user()));
++       Post::creating(static function (Post $post) {
++.           $post->author()->associate(Auth::user());
++       });
      }
 
      /**
@@ -326,7 +328,9 @@ the `serving()` method:
  {
 +    Auth::shouldUse('sanctum');
 +
-     Post::creating(static fn(Post $post) => $post->author()->associate(Auth::user()));
+     Post::creating(static function(Post $post) {
+         $post->author()->associate(Auth::user());
+     });
  }
 ```
 


### PR DESCRIPTION
Because the `creating` model event is executed in Laravel using the `until` (halt) strategy Laravel will call `creating` callbacks until the first one that returns something.

Since the example uses a short closure which thus returns the result of `associate` no further `creating` callbacks will be called, including those registered by other packages which results in undesired behaviour.