### PR TITLE
Fix for wrong "next chapter" link from step 3 -> 4

### DIFF
--- a/2.0/tutorial/03-server-and-schemas.md
+++ b/2.0/tutorial/03-server-and-schemas.md
@@ -669,5 +669,5 @@ In this chapter, we created our JSON:API server and added our first resource
 to it by creating a `PostSchema` class. We also learnt how to register JSON:API
 routes and how authentication works.
 
-In the [next chapter](./04-relationships), we'll add relationships to our
+In the [next chapter](./04-relationships.md), we'll add relationships to our
 `posts` resource.


### PR DESCRIPTION
This fixes a wrong link from step 3 in the bottom of the page linking to step 4