### PR TITLE
Migration classes are anonymous in Laravel 10

### DIFF
--- a/3.0/tutorial/02-models.md
+++ b/3.0/tutorial/02-models.md
@@ -51,7 +51,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreatePostsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -112,7 +112,7 @@ were created: the `_create_tags_table` and the `_create_comments_table` migratio
 In the `_create_tags_table` migration, we will add the following:
 
 ```diff
- class CreateTagsTable extends Migration
+ return new class extends Migration
  {
      /**
       * Run the migrations.


### PR DESCRIPTION
This command generate an anonymous migration class in Laravel 10:

```sh
vendor/bin/sail artisan make:model Post --migration
```