### PR TITLE
Update non-eloquent.md

### DIFF
--- a/3.0/digging-deeper/non-eloquent.md
+++ b/3.0/digging-deeper/non-eloquent.md
@@ -639,8 +639,8 @@ class SiteRepository extends AbstractRepository implements QueriesAll
     public function queryAll(): Capabilities\QuerySites
     {
         return Capabilities\QuerySites::make()
-            ->withServer($this->server)
-            ->withSchema($this->schema);
+            ->withServer($this->server())
+            ->withSchema($this->schema());
     }
 
 }


### PR DESCRIPTION
use `server()` and `schema()` methods instead of `server` and `schema` property.

This because, `withSchema` and `withServer` methods don't accept null as parameter.