### PR TITLE
Text Fixes

### DIFF
--- a/docs/1.x/schemas/sorting.md
+++ b/docs/1.x/schemas/sorting.md
@@ -87,7 +87,7 @@ This works for attributes that relate to a database column that can be sorted.
 
 Our sort field classes can be used to describe additional sort fields that a
 client is allowed to send for a particular resource type. To add a sort field to
-a schema, we can simply add it to the shcema's `sortables()` method.
+a schema, we can simply add it to the schema's `sortables()` method.
 
 To create a sort field, we use the static `make` method. For example, if we
 wanted to add a sort field to our `posts` resource:

--- a/docs/1.x/testing/resources.md
+++ b/docs/1.x/testing/resources.md
@@ -228,7 +228,7 @@ public function test(): void
         ->withData($data)
         ->patch('/api/v1/posts/' . $post->getRouteKey());
 
-    $response->assertFetchedOne($expected);
+    $response->assertFetchedOne($data);
 
     $this->assertDatabaseHas('posts', [
         'id' => $post->getKey(),

--- a/docs/2.x/schemas/sorting.md
+++ b/docs/2.x/schemas/sorting.md
@@ -87,7 +87,7 @@ This works for attributes that relate to a database column that can be sorted.
 
 Our sort field classes can be used to describe additional sort fields that a
 client is allowed to send for a particular resource type. To add a sort field to
-a schema, we can simply add it to the shcema's `sortables()` method.
+a schema, we can simply add it to the schema's `sortables()` method.
 
 To create a sort field, we use the static `make` method. For example, if we
 wanted to add a sort field to our `posts` resource:

--- a/docs/2.x/testing/resources.md
+++ b/docs/2.x/testing/resources.md
@@ -228,7 +228,7 @@ public function test(): void
         ->withData($data)
         ->patch('/api/v1/posts/' . $post->getRouteKey());
 
-    $response->assertFetchedOne($expected);
+    $response->assertFetchedOne($data);
 
     $this->assertDatabaseHas('posts', [
         'id' => $post->getKey(),

--- a/docs/3.x/schemas/sorting.md
+++ b/docs/3.x/schemas/sorting.md
@@ -87,7 +87,7 @@ This works for attributes that relate to a database column that can be sorted.
 
 Our sort field classes can be used to describe additional sort fields that a
 client is allowed to send for a particular resource type. To add a sort field to
-a schema, we can simply add it to the shcema's `sortables()` method.
+a schema, we can simply add it to the schema's `sortables()` method.
 
 To create a sort field, we use the static `make` method. For example, if we
 wanted to add a sort field to our `posts` resource:

--- a/docs/3.x/testing/resources.md
+++ b/docs/3.x/testing/resources.md
@@ -228,7 +228,7 @@ public function test(): void
         ->withData($data)
         ->patch('/api/v1/posts/' . $post->getRouteKey());
 
-    $response->assertFetchedOne($expected);
+    $response->assertFetchedOne($data);
 
     $this->assertDatabaseHas('posts', [
         'id' => $post->getKey(),

--- a/docs/4.x/schemas/sorting.md
+++ b/docs/4.x/schemas/sorting.md
@@ -87,7 +87,7 @@ This works for attributes that relate to a database column that can be sorted.
 
 Our sort field classes can be used to describe additional sort fields that a
 client is allowed to send for a particular resource type. To add a sort field to
-a schema, we can simply add it to the shcema's `sortables()` method.
+a schema, we can simply add it to the schema's `sortables()` method.
 
 To create a sort field, we use the static `make` method. For example, if we
 wanted to add a sort field to our `posts` resource:

--- a/docs/4.x/testing/resources.md
+++ b/docs/4.x/testing/resources.md
@@ -228,7 +228,7 @@ public function test(): void
         ->withData($data)
         ->patch('/api/v1/posts/' . $post->getRouteKey());
 
-    $response->assertFetchedOne($expected);
+    $response->assertFetchedOne($data);
 
     $this->assertDatabaseHas('posts', [
         'id' => $post->getKey(),

--- a/docs/5.x/schemas/sorting.md
+++ b/docs/5.x/schemas/sorting.md
@@ -87,7 +87,7 @@ This works for attributes that relate to a database column that can be sorted.
 
 Our sort field classes can be used to describe additional sort fields that a
 client is allowed to send for a particular resource type. To add a sort field to
-a schema, we can simply add it to the shcema's `sortables()` method.
+a schema, we can simply add it to the schema's `sortables()` method.
 
 To create a sort field, we use the static `make` method. For example, if we
 wanted to add a sort field to our `posts` resource:

--- a/docs/5.x/testing/resources.md
+++ b/docs/5.x/testing/resources.md
@@ -228,7 +228,7 @@ public function test(): void
         ->withData($data)
         ->patch('/api/v1/posts/' . $post->getRouteKey());
 
-    $response->assertFetchedOne($expected);
+    $response->assertFetchedOne($data);
 
     $this->assertDatabaseHas('posts', [
         'id' => $post->getKey(),


### PR DESCRIPTION
- Fix typo `shcema` to `schema`
- Fix example for resource updates to reference proper `$data` rather than missing `$expected` variable