### PR TITLE
Add full-text search

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -49,6 +49,41 @@ export default defineConfig({
         },
 
         outline: 'deep',
+
+        search: {
+            provider: 'local',
+            options: {
+                miniSearch: {
+                    searchOptions: {
+                        boostDocument(documentId, term) {
+                            documentId = documentId.toLowerCase();
+                            term = term.toLowerCase();
+
+                            // Exact page match
+                            if (documentId.endsWith(`/${term}.html#${term}`)) {
+                                return 100;
+                            }
+
+                            return 1;
+                        },
+                        boost: {
+                            title: 10,
+                            headers: 3,
+                            content: 1,
+                        },
+                    },
+                },
+                detailedView: false,
+                _render(src, env, md) {
+                    const path = env.relativePath || '';
+                    if (!path.startsWith('5.x/')) {
+                        return '';
+                    }
+
+                    return md.render(src, env);
+                },
+            },
+        },
     },
 
 })


### PR DESCRIPTION
This PRs adds support for local full-text search using [minisearch](https://lucaong.github.io/minisearch/classes/MiniSearch.MiniSearch.html).

Given that Vitepress doesn't support dynamic version switching/searching across different versions, i had to exclude pages that are not the latest version from the search.

The priority is given to pages with the exact title.

<img width="981" height="743" alt="Screenshot 2026-05-10 at 17 13 39" src="https://github.com/user-attachments/assets/052d2add-c5f8-4172-b05b-49a1627ade9f" />

<img width="981" height="743" alt="Screenshot 2026-05-10 at 17 13 43" src="https://github.com/user-attachments/assets/3c9ecf73-7dad-43ec-8f6f-ebd65b8d458f" />
